### PR TITLE
Recursively scrub log context array values

### DIFF
--- a/src/Processor.php
+++ b/src/Processor.php
@@ -51,39 +51,46 @@ class Processor implements ProcessorInterface
         return $record->with(message: $message, context: $context);
     }
 
-    private function scrub($message)
+    private function scrub($value)
     {
+        if (is_array($value)) {
+            foreach ($value as $key => $subValue) {
+                $value[$key] = $this->scrub($subValue);
+            }
+            return $value;
+        }
+
         // order filters are applied is important
         if ($this->urlPassword) {
-            $message = preg_replace(self::URL_PASSWORD_REGEX, self::FILTERED_URL_STR, $message);
+            $value = preg_replace(self::URL_PASSWORD_REGEX, self::FILTERED_URL_STR, $value);
         }
 
         if ($this->email) {
-            $message = preg_replace(self::EMAIL_REGEX, self::FILTERED_STR, $message);
+            $value = preg_replace(self::EMAIL_REGEX, self::FILTERED_STR, $value);
         }
 
         if ($this->creditCard) {
-            $message = preg_replace(self::CREDIT_CARD_REGEX, self::FILTERED_STR, $message);
-            $message = preg_replace(self::CREDIT_CARD_REGEX_DELIMITERS, self::FILTERED_STR, $message);
+            $value = preg_replace(self::CREDIT_CARD_REGEX, self::FILTERED_STR, $value);
+            $value = preg_replace(self::CREDIT_CARD_REGEX_DELIMITERS, self::FILTERED_STR, $value);
         }
 
         if ($this->phone) {
-            $message = preg_replace(self::E164_PHONE_REGEX, self::FILTERED_STR, $message);
-            $message = preg_replace(self::PHONE_REGEX, self::FILTERED_STR, $message);
+            $value = preg_replace(self::E164_PHONE_REGEX, self::FILTERED_STR, $value);
+            $value = preg_replace(self::PHONE_REGEX, self::FILTERED_STR, $value);
         }
 
         if ($this->ssn) {
-            $message = preg_replace(self::SSN_REGEX, self::FILTERED_STR, $message);
+            $value = preg_replace(self::SSN_REGEX, self::FILTERED_STR, $value);
         }
 
         if ($this->ip) {
-            $message = preg_replace(self::IP_REGEX, self::FILTERED_STR, $message);
+            $value = preg_replace(self::IP_REGEX, self::FILTERED_STR, $value);
         }
 
         if ($this->mac) {
-            $message = preg_replace(self::MAC_REGEX, self::FILTERED_STR, $message);
+            $value = preg_replace(self::MAC_REGEX, self::FILTERED_STR, $value);
         }
 
-        return $message;
+        return $value;
     }
 }

--- a/tests/ProcessorTest.php
+++ b/tests/ProcessorTest.php
@@ -104,6 +104,18 @@ final class ProcessorTest extends TestCase
         $this->assertStringNotContainsString('test@example.org', $contents);
     }
 
+    public function testContextWithMultiDemensionalArray()
+    {
+        $stream = fopen('php://memory', 'r+');
+        $logger = $this->createLogger($stream);
+        $logger->pushProcessor(new Logstop\Processor());
+
+        $logger->info('Hi', ['params' => ['userEmail' => 'test@example.org', 'name' => 'Alice']]);
+        $contents = $this->readStream($stream);
+        $this->assertStringContainsString('"userEmail":"[FILTERED]"', $contents);
+        $this->assertStringNotContainsString('test@example.org', $contents);
+    }
+
     public function testPsrLogMessageProcessorBefore()
     {
         $stream = fopen('php://memory', 'r+');


### PR DESCRIPTION
This Pull Request fixes the problem when the context value is a multidimentional array. Without recursively scrubbing the value, the process would result in `Notice:  Array to string conversion in ...`