### PR TITLE
Recursively scrub log array values

### DIFF
--- a/src/Processor.php
+++ b/src/Processor.php
@@ -19,25 +19,24 @@ class Processor implements ProcessorInterface
     private const URL_PASSWORD_REGEX = '/((?:\/\/|%2F%2F)\S+(?::|%3A))\S+(@|%40)/';
     private const MAC_REGEX = '/\b[0-9a-f]{2}(?:(?::|%3A)[0-9a-f]{2}){5}\b/i';
 
-    // TODO make private in 0.2.0
-    public $ip;
-    public $mac;
-    public $urlPassword;
-    public $email;
-    public $creditCard;
-    public $phone;
-    public $ssn;
+    private bool $ip;
+    private bool $mac;
+    private bool $urlPassword;
+    private bool $email;
+    private bool $creditCard;
+    private bool $phone;
+    private bool $ssn;
     private int $maxDepth;
 
     public function __construct(
-        $ip = false,
-        $mac = false,
-        $urlPassword = true,
-        $email = true,
-        $creditCard = true,
-        $phone = true,
-        $ssn = true,
-        int $maxDepth = 50
+        bool $ip = false,
+        bool $mac = false,
+        bool $urlPassword = true,
+        bool $email = true,
+        bool $creditCard = true,
+        bool $phone = true,
+        bool $ssn = true,
+        int  $maxDepth = 50
     ) {
         $this->ip = $ip;
         $this->mac = $mac;

--- a/src/Processor.php
+++ b/src/Processor.php
@@ -51,39 +51,46 @@ class Processor implements ProcessorInterface
         return $record->with(message: $message, context: $context);
     }
 
-    private function scrub($message)
+    private function scrub($value)
     {
+        if (is_array($value)) {
+            foreach ($value as $key => $subValue) {
+                $value[$key] = $this->scrub($subValue);
+            }
+            return $value;
+        }
+
         // order filters are applied is important
         if ($this->urlPassword) {
-            $message = preg_replace(self::URL_PASSWORD_REGEX, self::FILTERED_URL_STR, $message);
+            $value = preg_replace(self::URL_PASSWORD_REGEX, self::FILTERED_URL_STR, $value);
         }
 
         if ($this->email) {
-            $message = preg_replace(self::EMAIL_REGEX, self::FILTERED_STR, $message);
+            $value = preg_replace(self::EMAIL_REGEX, self::FILTERED_STR, $value);
         }
 
         if ($this->creditCard) {
-            $message = preg_replace(self::CREDIT_CARD_REGEX, self::FILTERED_STR, $message);
-            $message = preg_replace(self::CREDIT_CARD_REGEX_DELIMITERS, self::FILTERED_STR, $message);
+            $value = preg_replace(self::CREDIT_CARD_REGEX, self::FILTERED_STR, $value);
+            $value = preg_replace(self::CREDIT_CARD_REGEX_DELIMITERS, self::FILTERED_STR, $value);
         }
 
         if ($this->phone) {
-            $message = preg_replace(self::E164_PHONE_REGEX, self::FILTERED_STR, $message);
-            $message = preg_replace(self::PHONE_REGEX, self::FILTERED_STR, $message);
+            $value = preg_replace(self::E164_PHONE_REGEX, self::FILTERED_STR, $value);
+            $value = preg_replace(self::PHONE_REGEX, self::FILTERED_STR, $value);
         }
 
         if ($this->ssn) {
-            $message = preg_replace(self::SSN_REGEX, self::FILTERED_STR, $message);
+            $value = preg_replace(self::SSN_REGEX, self::FILTERED_STR, $value);
         }
 
         if ($this->ip) {
-            $message = preg_replace(self::IP_REGEX, self::FILTERED_STR, $message);
+            $value = preg_replace(self::IP_REGEX, self::FILTERED_STR, $value);
         }
 
         if ($this->mac) {
-            $message = preg_replace(self::MAC_REGEX, self::FILTERED_STR, $message);
+            $value = preg_replace(self::MAC_REGEX, self::FILTERED_STR, $value);
         }
 
-        return $message;
+        return $value;
     }
 }

--- a/src/Processor.php
+++ b/src/Processor.php
@@ -51,47 +51,47 @@ class Processor implements ProcessorInterface
         return $record->with(message: $message, context: $context);
     }
 
-    private function scrub($value)
+    private function scrub($message)
     {
-        if (is_array($value)) {
-            foreach ($value as $key => $subValue) {
-                $value[$key] = $this->scrub($subValue);
+        if (is_array($message)) {
+            foreach ($message as $key => $subValue) {
+                $message[$key] = $this->scrub($subValue);
             }
 
-            return $value;
+            return $message;
         }
 
         // order filters are applied is important
         if ($this->urlPassword) {
-            $value = preg_replace(self::URL_PASSWORD_REGEX, self::FILTERED_URL_STR, $value);
+            $message = preg_replace(self::URL_PASSWORD_REGEX, self::FILTERED_URL_STR, $message);
         }
 
         if ($this->email) {
-            $value = preg_replace(self::EMAIL_REGEX, self::FILTERED_STR, $value);
+            $message = preg_replace(self::EMAIL_REGEX, self::FILTERED_STR, $message);
         }
 
         if ($this->creditCard) {
-            $value = preg_replace(self::CREDIT_CARD_REGEX, self::FILTERED_STR, $value);
-            $value = preg_replace(self::CREDIT_CARD_REGEX_DELIMITERS, self::FILTERED_STR, $value);
+            $message = preg_replace(self::CREDIT_CARD_REGEX, self::FILTERED_STR, $message);
+            $message = preg_replace(self::CREDIT_CARD_REGEX_DELIMITERS, self::FILTERED_STR, $message);
         }
 
         if ($this->phone) {
-            $value = preg_replace(self::E164_PHONE_REGEX, self::FILTERED_STR, $value);
-            $value = preg_replace(self::PHONE_REGEX, self::FILTERED_STR, $value);
+            $message = preg_replace(self::E164_PHONE_REGEX, self::FILTERED_STR, $message);
+            $message = preg_replace(self::PHONE_REGEX, self::FILTERED_STR, $message);
         }
 
         if ($this->ssn) {
-            $value = preg_replace(self::SSN_REGEX, self::FILTERED_STR, $value);
+            $message = preg_replace(self::SSN_REGEX, self::FILTERED_STR, $message);
         }
 
         if ($this->ip) {
-            $value = preg_replace(self::IP_REGEX, self::FILTERED_STR, $value);
+            $message = preg_replace(self::IP_REGEX, self::FILTERED_STR, $message);
         }
 
         if ($this->mac) {
-            $value = preg_replace(self::MAC_REGEX, self::FILTERED_STR, $value);
+            $message = preg_replace(self::MAC_REGEX, self::FILTERED_STR, $message);
         }
 
-        return $value;
+        return $message;
     }
 }

--- a/src/Processor.php
+++ b/src/Processor.php
@@ -57,6 +57,7 @@ class Processor implements ProcessorInterface
             foreach ($value as $key => $subValue) {
                 $value[$key] = $this->scrub($subValue);
             }
+
             return $value;
         }
 

--- a/tests/ProcessorTest.php
+++ b/tests/ProcessorTest.php
@@ -144,6 +144,20 @@ final class ProcessorTest extends TestCase
         $this->assertStringNotContainsString('test@example.org', $contents);
     }
 
+    public function testMaxDepthReachedThrowsException()
+    {
+        $stream = fopen('php://memory', 'r+');
+        $logger = $this->createLogger($stream);
+        $logger->pushProcessor(new Logstop\Processor(maxDepth: 2));
+
+        $this->expectException(\RuntimeException::class);
+
+        $logger->info(
+            'Test',
+            ['params' => ['sql'=> ['user' => ['email' => 'test@example.org', 'name' => 'Alice']]]]
+        );
+    }
+
     private function assertFiltered($message, $expected = '[FILTERED]', ...$args)
     {
         $stream = fopen('php://memory', 'r+');

--- a/tests/ProcessorTest.php
+++ b/tests/ProcessorTest.php
@@ -104,15 +104,18 @@ final class ProcessorTest extends TestCase
         $this->assertStringNotContainsString('test@example.org', $contents);
     }
 
-    public function testContextWithMultiDemensionalArray()
+    public function testContextWithMultiDimensionalArray()
     {
         $stream = fopen('php://memory', 'r+');
         $logger = $this->createLogger($stream);
         $logger->pushProcessor(new Logstop\Processor());
 
-        $logger->info('Hi', ['params' => ['userEmail' => 'test@example.org', 'name' => 'Alice']]);
+        $logger->info(
+            'Hi',
+            ['params' => ['user' => ['email' => 'test@example.org', 'name' => 'Alice']]]
+        );
         $contents = $this->readStream($stream);
-        $this->assertStringContainsString('"userEmail":"[FILTERED]"', $contents);
+        $this->assertStringContainsString('"email":"[FILTERED]"', $contents);
         $this->assertStringNotContainsString('test@example.org', $contents);
     }
 

--- a/tests/ProcessorTest.php
+++ b/tests/ProcessorTest.php
@@ -110,12 +110,9 @@ final class ProcessorTest extends TestCase
         $logger = $this->createLogger($stream);
         $logger->pushProcessor(new Logstop\Processor());
 
-        $logger->info(
-            'Hi',
-            ['params' => ['user' => ['email' => 'test@example.org', 'name' => 'Alice']]]
-        );
+        $logger->info('Email Sent', ['params' => ['user' => ['email' => 'test@example.org', 'name' => 'Alice']]]);
         $contents = $this->readStream($stream);
-        $this->assertStringContainsString('"email":"[FILTERED]"', $contents);
+        $this->assertStringContainsString('"user":{"email":"[FILTERED]"', $contents);
         $this->assertStringNotContainsString('test@example.org', $contents);
     }
 

--- a/tests/ProcessorTest.php
+++ b/tests/ProcessorTest.php
@@ -104,6 +104,18 @@ final class ProcessorTest extends TestCase
         $this->assertStringNotContainsString('test@example.org', $contents);
     }
 
+    public function testContextWithMultiDemensionalArray()
+    {
+        $stream = fopen('php://memory', 'r+');
+        $logger = $this->createLogger($stream);
+        $logger->pushProcessor(new Logstop\Processor());
+
+        $logger->info('Hi', ['params' => ['userEmail' => 'test@example.org', 'name' => 'Alice']]);
+        $contents = $this->readStream($stream);
+        $this->assertStringContainsString('"userEmail":"[FILTERED]"', $contents);
+        $this->assertStringNotContainsString('test@example.org', $contents);
+    }
+
     public function testPsrLogMessageProcessorBefore()
     {
         $stream = fopen('php://memory', 'r+');


### PR DESCRIPTION
This pull request fixes the problem when the context value is a multidimentional array. Without recursively scrubbing the value, we would end up with `Array to string conversion` error

```
1) ProcessorTest::testContextWithMultiDemensionalArray
Array to string conversion

/app/src/Processor.php:58
/app/src/Processor.php:48
```